### PR TITLE
refactor and speed improvements

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter,benchmark}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ advent2023-*.tar
 
 # language server files
 .elixir_ls
+# benchmark data
+*.benchee

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ be found at <https://hexdocs.pm/tmp>.
 - feels like I have an overly complicated solution, reversing the list feels to get the final one feels bad
 - these docs are fantastic
 - integration with vscode and iex could be better, copy/pasting snippets into a terminal is annoying
+- [Benchee] is cool
+- moving the pattern matching up into the function _definition_ cleans things up a lot code-wise and perf wise. pattern matching is way faster than `Strings.starts_with?`
+- can do data-driven metaprogramming without diving all the way into `defmacro`
 
 
 ## References
@@ -32,3 +35,4 @@ be found at <https://hexdocs.pm/tmp>.
 - <https://hexdocs.pm/elixir/1.16/introduction.html>
 
 [Elixir]: https://elixir-lang.org/
+[Benchee]: https://elixirschool.com/en/lessons/misc/benchee

--- a/benchmark.exs
+++ b/benchmark.exs
@@ -1,0 +1,10 @@
+lines = File.stream!("./data/day1.txt")
+
+Benchee.run(
+  %{
+    "part 1" => fn -> Advent2023.Day1.solve(lines, :one) end,
+    "part 2" => fn -> Advent2023.Day1.solve(lines, :two) end
+  },
+  # save: %{}
+  load: "benchmark.benchee"
+)

--- a/lib/day1.ex
+++ b/lib/day1.ex
@@ -11,69 +11,45 @@ defmodule Advent2023.Day1 do
     |> Enum.sum()
   end
 
+  defp next_number(<<n>> <> _rest) when n in ?0..?9 do
+    n - 48
+  end
+
+  defp next_number(<<_>> <> rest) do
+    next_number(rest)
+  end
+
   defp value(line) do
-    lst =
-      for c <- String.graphemes(line),
-          v = Integer.parse(c),
-          v != :error do
-        c
-      end
-
-    [first | _] = lst
-    # this is dumb
-    [last | _] = Enum.reverse(lst)
-
-    # todo: Integer.undigits([first, last])
-    case Integer.parse(first <> last) do
-      {x, ""} -> x
-    end
-  end
-
-  # one:1, two:2, three:3, ...
-  @words "one two three four five six seven eight nine"
-         |> String.split()
-         |> Enum.with_index(&{&1, &2 + 1})
-         |> Enum.into([])
-  # eno:1, owt:2, eerht:3, ...
-  @reversed_words @words |> Enum.map(&put_elem(&1, 0, String.reverse(elem(&1, 0))))
-
-  defp leading_word_to_digit(line, dir) do
-    case dir do
-      :left_to_right -> @words
-      :right_to_left -> @reversed_words
-    end
-    |> Enum.filter(&String.starts_with?(line, elem(&1, 0)))
-    |> Enum.map(&elem(&1, 1))
-  end
-
-  defp leading_digit(line) do
-    String.at(line, 0) |> Integer.parse()
-  end
-
-  defp find_leading(line, dir) do
-    # why couldn't I get this to work in a flat cond?
-    case leading_digit(line) do
-      {d, ""} ->
-        d
-
-      # was getting match errors from :error if I tried to ignore it in the cond...
-      :error ->
-        case leading_word_to_digit(line, dir) do
-          [d] ->
-            d
-
-          _ ->
-            cond do
-              String.length(line) > 1 ->
-                find_leading(String.slice(line, 1..-1), dir)
-            end
-        end
-    end
+    first = line |> next_number
+    last = line |> String.reverse() |> next_number
+    Integer.undigits([first, last])
   end
 
   defp find_number(line) do
-    first = find_leading(line, :left_to_right)
-    last = String.reverse(line) |> find_leading(:right_to_left)
+    first = line |> next_word_number(:left_to_right)
+    last = line |> String.reverse() |> next_word_number(:right_to_left)
     Integer.undigits([first, last])
+  end
+
+  defp next_word_number(<<n>> <> _rest, _dir) when n in ?0..?9 do
+    n - 48
+  end
+
+  @words "one two three four five six seven eight nine"
+         |> String.split()
+         |> Enum.with_index()
+
+  for {word, idx} <- @words do
+    defp next_word_number(<<unquote(word)>> <> _rest, :left_to_right) do
+      unquote(idx + 1)
+    end
+
+    defp next_word_number(<<unquote(word |> String.reverse())>> <> _rest, :right_to_left) do
+      unquote(idx + 1)
+    end
+  end
+
+  defp next_word_number(<<_>> <> rest, dir) do
+    next_word_number(rest, dir)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Advent2023.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:benchee, "~> 1.0", only: :dev}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "benchee": {:hex, :benchee, "1.2.0", "afd2f0caec06ce3a70d9c91c514c0b58114636db9d83c2dc6bfd416656618353", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: true]}], "hexpm", "ee729e53217898b8fd30aaad3cce61973dab61574ae6f48229fe7ff42d5e4457"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+  "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
+}


### PR DESCRIPTION
The nested `case` didn't seem right, switch to pattern matching in function definitions, and that worked nicely.

benchmark results from before and after the change:

    Name                                      ips        average  deviation         median         99th %
    part 1                                 687.54        1.45 ms     ±2.23%        1.45 ms        1.55 ms
    part 2                                 673.30        1.49 ms     ±2.33%        1.48 ms        1.60 ms
    part 1 (2023-12-4--12-46-1-utc)        369.12        2.71 ms     ±3.07%        2.69 ms        2.99 ms
    part 2 (2023-12-4--12-46-1-utc)        135.84        7.36 ms     ±1.51%        7.34 ms        7.71 ms

    Comparison:
    part 1                                 687.54
    part 2                                 673.30 - 1.02x slower +0.0307 ms
    part 1 (2023-12-4--12-46-1-utc)        369.12 - 1.86x slower +1.25 ms
    part 2 (2023-12-4--12-46-1-utc)        135.84 - 5.06x slower +5.91 ms